### PR TITLE
Fixed Interpolation-only expressions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 # https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_rule.html
 resource "aws_cloudwatch_event_rule" "default" {
-  count = "${var.enabled == true ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
   name        = var.name
   description = var.description
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_event_rule" "default" {
 
 # https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html
 resource "aws_cloudwatch_event_target" "default" {
-  count = "${var.enabled == true ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
   target_id = var.name
   arn       = var.cluster_arn
@@ -120,7 +120,7 @@ locals {
 
 # https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html
 resource "aws_ecs_task_definition" "default" {
-  count = "${var.enabled == true ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
   # A unique name for your task definition.
   family = var.name


### PR DESCRIPTION
## Before

```
Warning: Interpolation-only expressions are deprecated

  on main.tf line 7, in resource "aws_cloudwatch_event_rule" "default":
   7:   count = "${var.enabled == true ? 1 : 0}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 2 more similar warnings elsewhere)
```