### PR TITLE
Adding ecs_task_role parameter to scheduled containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module "ecs_scheduled_task" {
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = var.ecs_task_execution_role_arn
   
-  ecs_task_role_arn    		= var.ecs_task_role_arn
+  ecs_task_role_arn        = var.ecs_task_role_arn
 
   tags = {
     Environment = "prod"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module "ecs_scheduled_task" {
 
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = var.ecs_task_execution_role_arn
-  
+
   ecs_task_role_arn        = var.ecs_task_role_arn
 
   tags = {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ module "ecs_scheduled_task" {
   ecs_events_role_arn    = var.ecs_events_role_arn
 
   create_ecs_task_execution_role = false
-  ecs_task_execution_role_arn    = var.ecs_events_role_arn
+  ecs_task_execution_role_arn    = var.ecs_task_execution_role_arn
+  
+  ecs_task_role_arn    		= var.ecs_task_role_arn
 
   tags = {
     Environment = "prod"
@@ -104,6 +106,7 @@ module "ecs_scheduled_task" {
 | description                    | The description of the all resources.                                             | `string`       | `"Managed by Terraform"`        |    no    |
 | ecs_events_role_arn            | The ARN of the CloudWatch Events IAM Role.                                        | `string`       | `""`                            |    no    |
 | ecs_task_execution_role_arn    | The ARN of the ECS Task Execution IAM Role.                                       | `string`       | `""`                            |    no    |
+| ecs_task_role_arn              | The ARN of the ECS Task IAM Role (to access AWS services from the container).     | `string`       | `""`                            |    no    |
 | enabled                        | Set to false to prevent the module from creating anything.                        | `bool`         | `true`                          |    no    |
 | iam_path                       | Path in which to create the IAM Role and the IAM Policy.                          | `string`       | `"/"`                           |    no    |
 | is_enabled                     | Whether the rule should be enabled.                                               | `string`       | `true`                          |    no    |

--- a/examples/complete/iam-event.tf
+++ b/examples/complete/iam-event.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "ecs_events" {
+  name               = "ecs-events-for-ecs-scheduled-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_events_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_events_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ecs_events" {
+  name   = aws_iam_role.ecs_events.name
+  policy = data.aws_iam_policy.ecs_events.policy
+}
+
+data "aws_iam_policy" "ecs_events" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_events" {
+  role       = aws_iam_role.ecs_events.name
+  policy_arn = aws_iam_policy.ecs_events.arn
+}

--- a/examples/complete/iam-task-execution.tf
+++ b/examples/complete/iam-task-execution.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = "ecs-task-execution-for-ecs-scheduled-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ecs_task_execution" {
+  name   = aws_iam_role.ecs_task_execution.name
+  policy = data.aws_iam_policy.ecs_task_execution.policy
+}
+
+data "aws_iam_policy" "ecs_task_execution" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = aws_iam_policy.ecs_task_execution.arn
+}

--- a/examples/complete/iam-task.tf
+++ b/examples/complete/iam-task.tf
@@ -1,0 +1,35 @@
+resource "aws_iam_role" "ecs_task" {
+  name               = "ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ecs_task_role_policy" {
+  name   = "ecs-task-policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ecs_task_role_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_role_policy" {
+    statement {
+    actions = [
+      "s3:list*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task" {
+  role       = aws_iam_role.ecs_task.name
+  policy_arn = aws_iam_policy.ecs_task_role_policy.arn
+}

--- a/examples/complete/iam-task.tf
+++ b/examples/complete/iam-task.tf
@@ -21,7 +21,7 @@ resource "aws_iam_policy" "ecs_task_role_policy" {
 }
 
 data "aws_iam_policy_document" "ecs_task_role_policy" {
-    statement {
+  statement {
     actions = [
       "s3:list*"
     ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,8 +40,8 @@ module "ecs_scheduled_task" {
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = aws_iam_role.ecs_task_execution.arn
 
-  ecs_task_role_arn    = aws_iam_role.ecs_task.arn
-  
+  ecs_task_role_arn = aws_iam_role.ecs_task.arn
+
   tags = {
     Environment = "prod"
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,69 +40,11 @@ module "ecs_scheduled_task" {
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = aws_iam_role.ecs_task_execution.arn
 
+  ecs_task_role_arn    = aws_iam_role.ecs_task.arn
+  
   tags = {
     Environment = "prod"
   }
-}
-
-resource "aws_iam_role" "ecs_events" {
-  name               = "ecs-events-for-ecs-scheduled-task"
-  assume_role_policy = data.aws_iam_policy_document.ecs_events_assume_role_policy.json
-}
-
-data "aws_iam_policy_document" "ecs_events_assume_role_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_policy" "ecs_events" {
-  name   = aws_iam_role.ecs_events.name
-  policy = data.aws_iam_policy.ecs_events.policy
-}
-
-data "aws_iam_policy" "ecs_events" {
-  arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_events" {
-  role       = aws_iam_role.ecs_events.name
-  policy_arn = aws_iam_policy.ecs_events.arn
-}
-
-resource "aws_iam_role" "ecs_task_execution" {
-  name               = "ecs-task-execution-for-ecs-scheduled-task"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume_role_policy.json
-}
-
-data "aws_iam_policy_document" "ecs_task_execution_assume_role_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_policy" "ecs_task_execution" {
-  name   = aws_iam_role.ecs_task_execution.name
-  policy = data.aws_iam_policy.ecs_task_execution.policy
-}
-
-data "aws_iam_policy" "ecs_task_execution" {
-  arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
-  role       = aws_iam_role.ecs_task_execution.name
-  policy_arn = aws_iam_policy.ecs_task_execution.arn
 }
 
 resource "aws_cloudwatch_log_group" "example" {

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,9 @@ resource "aws_ecs_task_definition" "default" {
 
   # The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
   execution_role_arn = var.create_ecs_task_execution_role ? join("", aws_iam_role.ecs_task_execution.*.arn) : var.ecs_task_execution_role_arn
+ 
+  # The ARN of the task role to give the container access to other AWS services
+  task_role_arn = var.ecs_task_role_arn
 
   # A list of container definitions in JSON format that describe the different containers that make up your task.
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_ecs_task_definition" "default" {
 
   # The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
   execution_role_arn = var.create_ecs_task_execution_role ? join("", aws_iam_role.ecs_task_execution.*.arn) : var.ecs_task_execution_role_arn
- 
+
   # The ARN of the task role to give the container access to other AWS services
   task_role_arn = var.ecs_task_role_arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,9 @@ variable "ecs_task_execution_role_arn" {
   type        = string
   description = "The ARN of the ECS Task Execution IAM Role."
 }
+
+variable "ecs_task_role_arn" {
+  default     = ""
+  type        = string
+  description = "The ARN of the ECS Task IAM Role. This gives the containers access to the specified aws services."
+}


### PR DESCRIPTION
Hi, 
I needed a scheduled container and I came across your module. 
I could almost use it, but I needed the ability to put S3 documents in a bucket from my container. 
The option exists in the terraform provider, I added it in the module. 
I also took the liberty of separating the iam stuff from the main.tf for readability. 

Thanks
Damien