### PR TITLE
Add a ecs_task_role_arn input variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ module "ecs_scheduled_task" {
 | description                    | The description of the all resources.                                             | `string`       | `"Managed by Terraform"`        |    no    |
 | ecs_events_role_arn            | The ARN of the CloudWatch Events IAM Role.                                        | `string`       | `""`                            |    no    |
 | ecs_task_execution_role_arn    | The ARN of the ECS Task Execution IAM Role.                                       | `string`       | `""`                            |    no    |
+| ecs_task_role_arn              | The ARN of the ECS Task IAM Role.                                                 | `string`       | `""`                            |    no    |
 | enabled                        | Set to false to prevent the module from creating anything.                        | `bool`         | `true`                          |    no    |
 | iam_path                       | Path in which to create the IAM Role and the IAM Policy.                          | `string`       | `"/"`                           |    no    |
 | is_enabled                     | Whether the rule should be enabled.                                               | `string`       | `true`                          |    no    |

--- a/main.tf
+++ b/main.tf
@@ -123,6 +123,8 @@ resource "aws_ecs_task_definition" "default" {
   # The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
   execution_role_arn = var.create_ecs_task_execution_role ? join("", aws_iam_role.ecs_task_execution.*.arn) : var.ecs_task_execution_role_arn
 
+  task_role_arn = var.ecs_task_role_arn
+
   # A list of container definitions in JSON format that describe the different containers that make up your task.
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions
   container_definitions = var.container_definitions

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,9 @@ variable "ecs_task_execution_role_arn" {
   type        = string
   description = "The ARN of the ECS Task Execution IAM Role."
 }
+
+variable "ecs_task_role_arn" {
+  default     = ""
+  type        = string
+  description = "The ARN of the ECS Task IAM Role."
+}


### PR DESCRIPTION
The variable is optional and can be used to set the `taskRoleArn` parameter of the task definition.